### PR TITLE
Add ability to filter sermon archive by series

### DIFF
--- a/libs/SermonArchive.php
+++ b/libs/SermonArchive.php
@@ -9,6 +9,7 @@ class SermonArchive
     protected $page_id;
     protected $sermons;
     protected $authors;
+    protected $series;
     protected $sermon;
 
     public function __construct()
@@ -34,6 +35,7 @@ class SermonArchive
         } else {
             $this->loadSermonsData();
             $this->loadAuthorData();
+            $this->loadSeriesData();
         }
     }
 
@@ -66,6 +68,7 @@ class SermonArchive
             CHURCH_SOCIAL_DOMAIN.'/public/church/'.$this->api_key.'/sermons?'.http_build_query([
                 'page' => isset($_GET['sermon_page']) ? $_GET['sermon_page'] : 1,
                 'author_id' => (isset($_GET['author_id']) ? $_GET['author_id'] : null),
+                'series_id' => (isset($_GET['series_id']) ? $_GET['series_id'] : null),
             ])
         );
 
@@ -96,6 +99,24 @@ class SermonArchive
 
         $response = json_decode($response['body'], true);
         $this->authors = $response['data'];
+    }
+
+    public function loadSeriesData()
+    {
+        if ($this->series) {
+            return;
+        }
+
+        $response = wp_remote_get(
+            CHURCH_SOCIAL_DOMAIN.'/public/church/'.$this->api_key.'/sermon-series'
+        );
+
+        if (!is_array($response) || $response['response']['code'] !== 200) {
+            return;
+        }
+
+        $response = json_decode($response['body'], true);
+        $this->series = $response['data'];
     }
 
     public function getPageTitle($title)

--- a/sass/sermon_archive.scss
+++ b/sass/sermon_archive.scss
@@ -8,6 +8,10 @@
 
     &__search_form_minister_select {}
 
+    &__search_form_series_label {}
+
+    &__search_form_series_select {}
+
     &__search_form_button {}
 
     &__table {}
@@ -53,6 +57,10 @@
     &__sermon_author_title {}
 
     &__sermon_author {}
+
+    &__sermon_series_title {}
+
+    &__sermon_series {}
 
     &__sermon_texts_title {}
 

--- a/views/sermon.php
+++ b/views/sermon.php
@@ -31,6 +31,13 @@
             </p>
         <?php endif ?>
 
+        <?php if ($this->sermon['series']): ?>
+            <h3 class="church_social_sermon_archive__sermon_series_title">Series:</h3>
+            <p class="church_social_sermon_archive__sermon_series">
+                <?php echo $this->sermon['series']['name'] ?>
+            </p>
+        <?php endif ?>
+
         <?php if ($this->sermon['texts']): ?>
             <h3 class="church_social_sermon_archive__sermon_texts_title">Texts:</h3>
             <ul class="church_social_sermon_archive__sermon_texts">

--- a/views/sermons.php
+++ b/views/sermons.php
@@ -1,24 +1,47 @@
 <div class="church_social_sermon_archive">
 
-    <?php if ($this->authors): ?>
+    <?php if ($this->authors || $this->series): ?>
         <form class="church_social_sermon_archive__search_form">
             <input type="hidden" name="sermon_page" value="1">
             <p>
-                <label class="church_social_sermon_archive__search_form_minister_label" for="church_social_sermon_archive__search_form_minister_select">Minister:</label>
-                <select class="church_social_sermon_archive__search_form_minister_select" name="author_id" id="church_social_sermon_archive__search_form_minister_select">
-                    <option></option>
-                    <?php foreach ($this->authors as $author): ?>
-                        <?php if (isset($_GET['author_id']) and $_GET['author_id'] == $author['id']): ?>
-                            <option value="<?php echo $author['id'] ?>" selected="selected">
-                                <?php echo $author['last_name'] ?>, <?php echo $author['title'] ? $author['title'].' '.$author['first_name'] : $author['first_name'] ?>
-                            </option>
-                        <?php else: ?>
-                            <option value="<?php echo $author['id'] ?>">
-                                <?php echo $author['last_name'] ?>, <?php echo $author['title'] ? $author['title'].' '.$author['first_name'] : $author['first_name'] ?>
-                            </option>
-                        <?php endif ?>
-                    <?php endforeach ?>
-                </select>
+                <?php if ($this->authors): ?>
+                    <span style="white-space: nowrap;">
+                        <label class="church_social_sermon_archive__search_form_minister_label" for="church_social_sermon_archive__search_form_minister_select">Minister:</label>
+                        <select class="church_social_sermon_archive__search_form_minister_select" name="author_id" id="church_social_sermon_archive__search_form_minister_select">
+                            <option></option>
+                            <?php foreach ($this->authors as $author): ?>
+                                <?php if (isset($_GET['author_id']) and $_GET['author_id'] == $author['id']): ?>
+                                    <option value="<?php echo $author['id'] ?>" selected="selected">
+                                        <?php echo $author['last_name'] ?>, <?php echo $author['title'] ? $author['title'].' '.$author['first_name'] : $author['first_name'] ?>
+                                    </option>
+                                <?php else: ?>
+                                    <option value="<?php echo $author['id'] ?>">
+                                        <?php echo $author['last_name'] ?>, <?php echo $author['title'] ? $author['title'].' '.$author['first_name'] : $author['first_name'] ?>
+                                    </option>
+                                <?php endif ?>
+                            <?php endforeach ?>
+                        </select>
+                    </span>
+                <?php endif ?>
+                <?php if ($this->series): ?>
+                    <span style="white-space: nowrap;">
+                        <label class="church_social_sermon_archive__search_form_series_label" for="church_social_sermon_archive__search_form_series_select">Series:</label>
+                        <select class="church_social_sermon_archive__search_form_series_select" name="series_id" id="church_social_sermon_archive__search_form_series_select">
+                            <option></option>
+                            <?php foreach ($this->series as $series): ?>
+                                <?php if (isset($_GET['series_id']) and $_GET['series_id'] == $series['id']): ?>
+                                    <option value="<?php echo $series['id'] ?>" selected="selected">
+                                        <?php echo $series['title'] ?> (<?php echo $series['sermons'] ?>)
+                                    </option>
+                                <?php else: ?>
+                                    <option value="<?php echo $series['id'] ?>">
+                                        <?php echo $series['title'] ?> (<?php echo $series['sermons'] ?>)
+                                    </option>
+                                <?php endif ?>
+                            <?php endforeach ?>
+                        </select>
+                    </span>
+                <?php endif ?>
                 <button class="church_social_sermon_archive__search_form_button" type="submit">Search</button>
             </p>
         </form>
@@ -72,12 +95,12 @@
 
     <p class="church_social_sermon_archive__prev_and_next_page_buttons">
         <?php if ($this->meta['previous_page']): ?>
-            <a class="church_social_sermon_archive__prev_page_button" href="?sermon_page=<?php echo $this->meta['previous_page']?><?php echo isset($_GET['author_id']) ? '&author_id='.$_GET['author_id'] : '' ?>">
+            <a class="church_social_sermon_archive__prev_page_button" href="?sermon_page=<?php echo $this->meta['previous_page']?><?php echo isset($_GET['author_id']) ? '&author_id='.$_GET['author_id'] : '' ?><?php echo isset($_GET['series_id']) ? '&series_id='.$_GET['series_id'] : '' ?>">
                 Previous page
             </a>
         <?php endif ?>
         <?php if ($this->meta['next_page']): ?>
-            <a class="church_social_sermon_archive__next_page_button" href="?sermon_page=<?php echo $this->meta['next_page']?><?php echo isset($_GET['author_id']) ? '&author_id='.$_GET['author_id'] : '' ?>">
+            <a class="church_social_sermon_archive__next_page_button" href="?sermon_page=<?php echo $this->meta['next_page']?><?php echo isset($_GET['author_id']) ? '&author_id='.$_GET['author_id'] : '' ?><?php echo isset($_GET['series_id']) ? '&series_id='.$_GET['series_id'] : '' ?>">
                 Next page
             </a>
         <?php endif ?>


### PR DESCRIPTION
This PR adds the ability to filter the sermon archive by a sermon series. This also shows the sermon series (if any) in the sermon details.

The addition of the sermon series dropdown may break some websites' custom styling, but I checked several of the websites that use this sermon archive page, and I didn't find any that would change too much.

I tried to be consistent with the existing coding styles, but that also includes the fact that lots of content doesn't seem to be escaped properly. This isn't too much of an issue since only the people with the ability to create/edit sermons can set the text content.

I tested these changes against Wordpress 6.6.1, but I would appreciate further review, testing, and suggestions.